### PR TITLE
Add --tag-format option to the release command

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ Create a new release:
 changelog release 1.2.4
 ```
 
+If you use a prefix for git tags, specify a tag format:
+
+```bash
+changelog release --tag-format "v%s" 1.2.4
+```
+
 ### Formatting
 
 `fmt` command normalizes the changelog file. The idea is to always have

--- a/chg/changelog.go
+++ b/chg/changelog.go
@@ -78,7 +78,7 @@ func (c *Changelog) AddItem(section ChangeType, message string) {
 }
 
 // Release transforms Unreleased into the version informed
-func (c *Changelog) Release(newVersion Version) (*Version, error) {
+func (c *Changelog) Release(newVersion Version, tagPattern string) (*Version, error) {
 	oldUnreleased := c.Version("Unreleased")
 	var prevVersion *Version
 	if len(c.Versions) > 1 {
@@ -101,17 +101,17 @@ func (c *Changelog) Release(newVersion Version) (*Version, error) {
 		compareURL = strings.Replace(newVersion.Link, "<prev>", newVersion.Name, -1)
 		compareURL = strings.Replace(compareURL, "<next>", "HEAD", -1)
 	} else if prevVersion == nil || prevVersion.Link == "" {
-		r := regexp.MustCompile(`(\w[\w\.]*?)\.{2,3}(\w[\w\.]*?)$`)
+		r := regexp.MustCompile(`(\w[\w.]*?)\.{2,3}(\w[\w.]*?)$`)
 		r.MatchString(oldUnreleased.Link)
 		matches := r.FindStringSubmatch(oldUnreleased.Link)
-		compareURL = strings.Replace(oldUnreleased.Link, matches[1], newVersion.Name, -1)
+		compareURL = strings.Replace(oldUnreleased.Link, matches[1], fmt.Sprintf(tagPattern, newVersion.Name), -1)
 	} else {
-		compareURL = strings.Replace(oldUnreleased.Link, prevVersion.Name, newVersion.Name, -1)
+		compareURL = strings.Replace(oldUnreleased.Link, fmt.Sprintf(tagPattern, prevVersion.Name), fmt.Sprintf(tagPattern, newVersion.Name), -1)
 	}
 
 	newUnreleased.Link = compareURL
 
-	oldUnreleased.Link = strings.Replace(oldUnreleased.Link, "HEAD", newVersion.Name, -1)
+	oldUnreleased.Link = strings.Replace(oldUnreleased.Link, "HEAD", fmt.Sprintf(tagPattern, newVersion.Name), -1)
 	oldUnreleased.Name = newVersion.Name
 	oldUnreleased.Date = newVersion.Date
 

--- a/chg/changelog.go
+++ b/chg/changelog.go
@@ -78,7 +78,7 @@ func (c *Changelog) AddItem(section ChangeType, message string) {
 }
 
 // Release transforms Unreleased into the version informed
-func (c *Changelog) Release(newVersion Version, tagPattern string) (*Version, error) {
+func (c *Changelog) Release(newVersion Version, tagFormat string) (*Version, error) {
 	oldUnreleased := c.Version("Unreleased")
 	var prevVersion *Version
 	if len(c.Versions) > 1 {
@@ -104,14 +104,14 @@ func (c *Changelog) Release(newVersion Version, tagPattern string) (*Version, er
 		r := regexp.MustCompile(`(\w[\w.]*?)\.{2,3}(\w[\w.]*?)$`)
 		r.MatchString(oldUnreleased.Link)
 		matches := r.FindStringSubmatch(oldUnreleased.Link)
-		compareURL = strings.Replace(oldUnreleased.Link, matches[1], fmt.Sprintf(tagPattern, newVersion.Name), -1)
+		compareURL = strings.Replace(oldUnreleased.Link, matches[1], fmt.Sprintf(tagFormat, newVersion.Name), -1)
 	} else {
-		compareURL = strings.Replace(oldUnreleased.Link, fmt.Sprintf(tagPattern, prevVersion.Name), fmt.Sprintf(tagPattern, newVersion.Name), -1)
+		compareURL = strings.Replace(oldUnreleased.Link, fmt.Sprintf(tagFormat, prevVersion.Name), fmt.Sprintf(tagFormat, newVersion.Name), -1)
 	}
 
 	newUnreleased.Link = compareURL
 
-	oldUnreleased.Link = strings.Replace(oldUnreleased.Link, "HEAD", fmt.Sprintf(tagPattern, newVersion.Name), -1)
+	oldUnreleased.Link = strings.Replace(oldUnreleased.Link, "HEAD", fmt.Sprintf(tagFormat, newVersion.Name), -1)
 	oldUnreleased.Name = newVersion.Name
 	oldUnreleased.Date = newVersion.Date
 

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -25,6 +25,7 @@ It will normalize the output with the new version.
 
 			releaseDate, _ := fs.GetString("release-date")
 			compareURL, _ := fs.GetString("compare-url")
+			tagPattern, _ := fs.GetString("tag-pattern")
 
 			version := chg.Version{
 				Name: args[0],
@@ -37,7 +38,7 @@ It will normalize the output with the new version.
 
 			changelog := parser.Parse(iostreams.In)
 
-			_, err := changelog.Release(version)
+			_, err := changelog.Release(version, tagPattern)
 			if err != nil {
 				cmd.SilenceUsage = true
 				return fmt.Errorf("Failed to create release '%s': %s\n", args[0], err)
@@ -53,6 +54,7 @@ It will normalize the output with the new version.
 	today := time.Now().Format(dateFormat)
 	fs.StringP("release-date", "d", today, "Release date")
 	fs.StringP("compare-url", "c", "", "Overwrite compare URL for Unreleased section")
+	fs.StringP("tag-pattern", "t", "%s", "Printf pattern to use for tags in compare urls")
 
 	return cmd
 }

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -25,7 +25,7 @@ It will normalize the output with the new version.
 
 			releaseDate, _ := fs.GetString("release-date")
 			compareURL, _ := fs.GetString("compare-url")
-			tagPattern, _ := fs.GetString("tag-pattern")
+			tagFormat, _ := fs.GetString("tag-format")
 
 			version := chg.Version{
 				Name: args[0],
@@ -38,7 +38,7 @@ It will normalize the output with the new version.
 
 			changelog := parser.Parse(iostreams.In)
 
-			_, err := changelog.Release(version, tagPattern)
+			_, err := changelog.Release(version, tagFormat)
 			if err != nil {
 				cmd.SilenceUsage = true
 				return fmt.Errorf("Failed to create release '%s': %s\n", args[0], err)
@@ -54,7 +54,7 @@ It will normalize the output with the new version.
 	today := time.Now().Format(dateFormat)
 	fs.StringP("release-date", "d", today, "Release date")
 	fs.StringP("compare-url", "c", "", "Overwrite compare URL for Unreleased section")
-	fs.StringP("tag-pattern", "t", "%s", "Printf pattern to use for tags in compare urls")
+	fs.StringP("tag-format", "t", "%s", "Printf format string to use for tags in compare urls")
 
 	return cmd
 }

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"io/ioutil"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -97,6 +98,72 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 	// Missing --compare-url, as the autodetect won't work for the minimal changelog
 	release.SetArgs([]string{"0.1.0", "--release-date", "2018-06-18"})
 	_, err = release.ExecuteC()
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, string(out.Bytes()))
+}
+
+func TestReleaseCmdWithTagPattern(t *testing.T) {
+	changelog := `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Item 3
+
+## [0.0.2]
+### Added
+- Item 2
+
+## [0.0.1]
+### Added
+- Item 1
+
+[Unreleased]: https://github.com/rcmachado/changelog/compare/v0.0.2...HEAD
+[0.0.2]: https://github.com/rcmachado/changelog/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/rcmachado/changelog/compare/ae761ff...v0.0.1
+`
+
+	expected := `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2021-10-18
+### Added
+- Item 3
+
+## [0.0.2]
+### Added
+- Item 2
+
+## [0.0.1]
+### Added
+- Item 1
+
+[Unreleased]: https://github.com/rcmachado/changelog/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/rcmachado/changelog/compare/v0.0.2...v0.1.0
+[0.0.2]: https://github.com/rcmachado/changelog/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/rcmachado/changelog/compare/ae761ff...v0.0.1
+`
+
+	out := new(bytes.Buffer)
+	iostreams := &IOStreams{
+		In:  strings.NewReader(changelog),
+		Out: out,
+	}
+
+	release := newReleaseCmd(iostreams)
+	release.SetArgs([]string{"0.1.0", "--release-date", "2021-10-18", "--tag-pattern", "v%s"})
+	_, err := release.ExecuteC()
 
 	assert.Nil(t, err)
 	assert.Equal(t, expected, string(out.Bytes()))

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -162,7 +162,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 	}
 
 	release := newReleaseCmd(iostreams)
-	release.SetArgs([]string{"0.1.0", "--release-date", "2021-10-18", "--tag-pattern", "v%s"})
+	release.SetArgs([]string{"0.1.0", "--release-date", "2021-10-18", "--tag-format", "v%s"})
 	_, err := release.ExecuteC()
 
 	assert.Nil(t, err)


### PR DESCRIPTION
Some projects use a `v` prefix in front of tags, as illustrated by the older tags in [this changelog](https://raw.githubusercontent.com/cucumber/language-service/67cb4da43ef6d36f84d59ca4dd4f0df897e106f7/CHANGELOG.md).

The [KAC spec](https://keepachangelog.com/en/1.0.0/) does not mandate a particular format for git tags, but the example in the spec uses a `v` prefix. It seems we should allow some flexibility around this, to cater for different practices.

This PR adds a new `--tag-format` option where the user can specify a [printf](https://en.wikipedia.org/wiki/Printf_format_string) format (for example `v%s`).

This should allow us to create correct links in the bottom of the changelog.