### PR TITLE
Remove deprecated fields from goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,10 +10,6 @@ builds:
 dockers:
   - goos: linux
     goarch: amd64
-    builds:
-      - changelog
-    binaries:
-      - changelog
     dockerfile: Dockerfile.goreleaser
     image_templates:
       - "cucumber/{{.ProjectName}}:{{.Tag}}"


### PR DESCRIPTION
I'm not sure what either of these were supposed to do, but they appear to have been [removed from the config schema](https://goreleaser.com/deprecations/#dockerbinary).

Current options are here: https://goreleaser.com/customization/docker/