### PR TITLE
Support indented bullets in changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Allow nested bullets under a change item ([#16](https://github.com/cucumber/changelog/pull/16))
 
 ## [0.10.0] - 2021-11-11
 ### Added
@@ -19,7 +21,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - config for releasing to Cucumber's docker account
 
 ## [0.9.1] - 2021-11-11
-Failed release
 
 ## [0.9.0] - 2021-11-11
 ### Fixed

--- a/chg/change.go
+++ b/chg/change.go
@@ -93,7 +93,7 @@ func NewChangeList(ct string) *ChangeList {
 // RenderItems renders all the items
 func (c *ChangeList) RenderItems(w io.Writer) {
 	for _, i := range c.Items {
-		i.Render(w)
+		i.Render(w, 0)
 	}
 }
 

--- a/chg/change_test.go
+++ b/chg/change_test.go
@@ -40,9 +40,9 @@ func TestNewChangeList(t *testing.T) {
 func TestChangeListRenderItems(t *testing.T) {
 	c := ChangeList{
 		Items: []*Item{
-			{"Item 1"},
-			{"Item 2"},
-			{"Item 3"},
+			{Description: "Item 1"},
+			{Description: "Item 2"},
+			{Description: "Item 3"},
 		},
 	}
 	expected := `- Item 1
@@ -61,7 +61,7 @@ func TestChangeRender(t *testing.T) {
 	c := ChangeList{
 		Type: Added,
 		Items: []*Item{
-			{"something"},
+			{Description: "something"},
 		},
 	}
 

--- a/chg/changelog_test.go
+++ b/chg/changelog_test.go
@@ -166,7 +166,8 @@ func TestChangelogEncodeJson(t *testing.T) {
           "type": "added",
           "items": [
             {
-              "description": "New feature"
+              "description": "New feature",
+              "items": null
             }
           ]
         }

--- a/chg/item.go
+++ b/chg/item.go
@@ -3,14 +3,20 @@ package chg
 import (
 	"fmt"
 	"io"
+	"strings"
 )
 
 // Item holds the change itself
 type Item struct {
-	Description string `json:"description"`
+	Description string  `json:"description"`
+	Items       []*Item `json:"items"`
 }
 
 // Render renders the change as a list item
-func (i *Item) Render(w io.Writer) {
-	io.WriteString(w, fmt.Sprintf("- %s\n", i.Description))
+func (i *Item) Render(w io.Writer, indent int) {
+	bullet := fmt.Sprintf("%s- %s\n", strings.Repeat(" ", indent), i.Description)
+	io.WriteString(w, bullet)
+	for _, c := range i.Items {
+		c.Render(w, indent+2)
+	}
 }

--- a/chg/item_test.go
+++ b/chg/item_test.go
@@ -8,11 +8,23 @@ import (
 )
 
 func TestItemRender(t *testing.T) {
-	i := Item{"Item 1"}
+	i := Item{Description: "Item 1"}
 	expected := "- Item 1\n"
 
 	var buf bytes.Buffer
-	i.Render(&buf)
+	i.Render(&buf, 0)
+	result := buf.String()
+
+	assert.Equal(t, expected, result)
+}
+
+func TestItemRenderWithChildren(t *testing.T) {
+	c := &Item{Description: "a detail"}
+	i := Item{Description: "Item 1", Items: []*Item{c}}
+	expected := "- Item 1\n  - a detail\n"
+
+	var buf bytes.Buffer
+	i.Render(&buf, 0)
 	result := buf.String()
 
 	assert.Equal(t, expected, result)

--- a/chg/version_test.go
+++ b/chg/version_test.go
@@ -111,15 +111,15 @@ func TestRenderChanges(t *testing.T) {
 		{
 			Type: Added,
 			Items: []*Item{
-				{"Item 1"},
-				{"Item 2"},
+				{Description: "Item 1"},
+				{Description: "Item 2"},
 			},
 		},
 		{
 			Type: Changed,
 			Items: []*Item{
-				{"Item A"},
-				{"Item B"},
+				{Description: "Item A"},
+				{Description: "Item B"},
 			},
 		},
 	}
@@ -147,15 +147,15 @@ func TestVersionRender(t *testing.T) {
 		{
 			Type: Added,
 			Items: []*Item{
-				{"Item 1"},
-				{"Item 2"},
+				{Description: "Item 1"},
+				{Description: "Item 2"},
 			},
 		},
 		{
 			Type: Changed,
 			Items: []*Item{
-				{"Item A"},
-				{"Item B"},
+				{Description: "Item A"},
+				{Description: "Item B"},
 			},
 		},
 	}

--- a/cmd/fmt_test.go
+++ b/cmd/fmt_test.go
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Command A
 - Command B
+  - a detail
+  - another detail
 - Command C
 
 [Unreleased]: https://github.com/rcmachado/changelog/compare/0.2.0...HEAD
@@ -54,6 +56,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Command A
 - Command B
+  - a detail
+  - another detail
 - Command C
 
 [Unreleased]: https://github.com/rcmachado/changelog/compare/0.2.0...HEAD
@@ -105,7 +109,8 @@ Hello
           "type": "changed",
           "items": [
             {
-              "description": "Out of order entries"
+              "description": "Out of order entries",
+              "items": null
             }
           ]
         },
@@ -113,7 +118,8 @@ Hello
           "type": "added",
           "items": [
             {
-              "description": "Something else"
+              "description": "Something else",
+              "items": null
             }
           ]
         }
@@ -129,7 +135,8 @@ Hello
           "type": "added",
           "items": [
             {
-              "description": "Command A"
+              "description": "Command A",
+              "items": null
             }
           ]
         }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -34,13 +34,13 @@ func TestParserParse(t *testing.T) {
 						{
 							Type: chg.Added,
 							Items: []*chg.Item{
-								{"Awesome feature that people always asked for"},
+								{Description: "Awesome feature that people always asked for"},
 							},
 						},
 						{
 							Type: chg.Fixed,
 							Items: []*chg.Item{
-								{"That annoying bug"},
+								{Description: "That annoying bug"},
 							},
 						},
 					},
@@ -54,7 +54,7 @@ func TestParserParse(t *testing.T) {
 						{
 							Type: chg.Security,
 							Items: []*chg.Item{
-								{"Remote code execution using our eval endpoint"},
+								{Description: "Remote code execution using our eval endpoint"},
 							},
 						},
 					},
@@ -133,13 +133,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 						{
 							Type: chg.Added,
 							Items: []*chg.Item{
-								{"Awesome feature that people always asked for"},
+								{Description: "Awesome feature that people always asked for"},
 							},
 						},
 						{
 							Type: chg.Fixed,
 							Items: []*chg.Item{
-								{"That annoying bug"},
+								{Description: "That annoying bug"},
 							},
 						},
 					},
@@ -152,7 +152,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 						{
 							Type: chg.Security,
 							Items: []*chg.Item{
-								{"Remote code execution using our eval endpoint"},
+								{Description: "Remote code execution using our eval endpoint"},
 							},
 						},
 					},
@@ -177,8 +177,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 						{
 							Type: chg.Added,
 							Items: []*chg.Item{
-								{"Item 1"},
-								{"Item 2"},
+								{Description: "Item 1"},
+								{Description: "Item 2"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		result := parser.Parse(input)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("indented-bullets", func(t *testing.T) {
+		input := readFile(t, "indented-bullets")
+
+		expected := &chg.Changelog{
+			Preamble: "Simple paragraph.",
+			Versions: []*chg.Version{
+				{
+					Name: "Unreleased",
+					Link: "http://example.com/abcdef..HEAD",
+					Changes: []*chg.ChangeList{
+						{
+							Type: chg.Added,
+							Items: []*chg.Item{
+								{
+									Description: "Item 1",
+									Items: []*chg.Item{
+										{
+											Description: "a detail",
+										},
+									},
+								},
 							},
 						},
 					},

--- a/parser/testdata/indented-bullets.md
+++ b/parser/testdata/indented-bullets.md
@@ -1,0 +1,10 @@
+# Changelog
+
+Simple paragraph.
+
+## [Unreleased]
+### Added
+- Item 1
+	- a detail
+
+[Unreleased]: http://example.com/abcdef..HEAD


### PR DESCRIPTION
### 🤔 What's changed?

You can now nest bullets beneath individual changes

### ⚡️ What's your motivation? 

Don't [mangle the changelog for cucumber/messages](https://github.com/cucumber/messages/pull/42).

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

I'm not 100% sure on my use of `&` and `*` but things seem to work...

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
