### PR TITLE
Add a fix for mangling longer CHANGELOGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Allow nested bullets under a change item ([#16](https://github.com/cucumber/changelog/pull/16))
+- Stop mangling changelogs when reformatting makes the file shorter than the original ([#17](https://github.com/cucumber/changelog/pull/17))
 
 ## [0.10.0] - 2021-11-11
 ### Added

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -24,11 +26,16 @@ var rootCmd = &cobra.Command{
 	Long:  `changelog manipulate and validate markdown changelog files following the keepachangelog.com specification.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		fs := cmd.Flags()
-
 		fdr := openFileOrExit(fs, "filename", os.O_RDONLY, os.Stdin)
-		ioStreams.In = bufio.NewReader(fdr)
+		input, err := ioutil.ReadAll(fdr)
+		if err != nil {
+			fmt.Printf("Failed to read input: %v", err)
+			os.Exit(1)
+		}
+		fdr.Close()
+		ioStreams.In = bytes.NewReader(input)
 
-		fdw := openFileOrExit(fs, "output", os.O_WRONLY|os.O_CREATE, os.Stdout)
+		fdw := openFileOrExit(fs, "output", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.Stdout)
 		ioStreams.Out = bufio.NewWriter(fdw)
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
### 🤔 What's changed?

This reads the whole file in and closes it before attempting to open the file for writing, thereby avoiding the situation where we start writing to the file (and truncating it) before we've read it in, or overwrite the existing file and leave old bytes at the end.

### ⚡️ What's your motivation? 

Fix #9 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

There are no tests for this because the code in `root.go` is not (yet!) tested. I've tested it manually.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
